### PR TITLE
Feature.registration confirms password

### DIFF
--- a/lib/harmony/account/user.ex
+++ b/lib/harmony/account/user.ex
@@ -100,7 +100,7 @@ defmodule Harmony.Account.User do
   def password_changeset(user, attrs, opts \\ []) do
     user
     |> cast(attrs, [:password])
-    |> validate_confirmation(:password, message: "does not match password")
+    |> validate_confirmation(:password, message: "does not match password", required: true)
     |> validate_password(opts)
   end
 

--- a/lib/harmony/account/user.ex
+++ b/lib/harmony/account/user.ex
@@ -33,7 +33,7 @@ defmodule Harmony.Account.User do
     |> cast(attrs, [:email, :password])
     |> validate_email()
     |> validate_password(opts)
-    |> validate_confirmation(:password, message: "does not match password")
+    |> validate_confirmation(:password, message: "does not match password", required: true)
   end
 
   defp validate_email(changeset) do

--- a/lib/harmony/account/user.ex
+++ b/lib/harmony/account/user.ex
@@ -33,6 +33,7 @@ defmodule Harmony.Account.User do
     |> cast(attrs, [:email, :password])
     |> validate_email()
     |> validate_password(opts)
+    |> validate_confirmation(:password, message: "does not match password")
   end
 
   defp validate_email(changeset) do

--- a/lib/harmony_web/templates/user_registration/new.html.heex
+++ b/lib/harmony_web/templates/user_registration/new.html.heex
@@ -22,6 +22,13 @@
   </div>
 
   <div class="mb-3">
+    <%= label f, :password_confirmation, class: "form-label" %>
+    <%= password_input f, :password_confirmation, required: true,
+      class: maybe_invalid("form-control", f, :password_confirmation) %>
+    <%= error_tag f, :password_confirmation %>
+  </div>
+
+ <div class="mb-3">
     <%= submit "Register", class: "btn btn-primary form-control" %>
   </div>
 </.form>

--- a/test/harmony/account_test.exs
+++ b/test/harmony/account_test.exs
@@ -54,6 +54,7 @@ defmodule Harmony.AccountTest do
 
       assert %{
                password: ["can't be blank"],
+               password_confirmation: ["does not match password"],
                email: ["can't be blank"]
              } = errors_on(changeset)
     end

--- a/test/harmony/account_test.exs
+++ b/test/harmony/account_test.exs
@@ -259,7 +259,7 @@ defmodule Harmony.AccountTest do
     test "allows fields to be set" do
       changeset =
         Account.change_user_password(%User{}, %{
-          "password" => "new valid password"
+          "password" => "new valid password", "password_confirmation" => "new valid password"
         })
 
       assert changeset.valid?
@@ -290,14 +290,14 @@ defmodule Harmony.AccountTest do
       too_long = String.duplicate("db", 100)
 
       {:error, changeset} =
-        Account.update_user_password(user, valid_user_password(), %{password: too_long})
+        Account.update_user_password(user, valid_user_password(), %{password: too_long, password_confirmation: too_long})
 
       assert "should be at most 72 character(s)" in errors_on(changeset).password
     end
 
     test "validates current password", %{user: user} do
       {:error, changeset} =
-        Account.update_user_password(user, "invalid", %{password: valid_user_password()})
+        Account.update_user_password(user, "invalid", %{password: valid_user_password(), password_confirmation: valid_user_password()})
 
       assert %{current_password: ["is not valid"]} = errors_on(changeset)
     end
@@ -305,7 +305,7 @@ defmodule Harmony.AccountTest do
     test "updates the password", %{user: user} do
       {:ok, user} =
         Account.update_user_password(user, valid_user_password(), %{
-          password: "new valid password"
+          password: "new valid password", password_confirmation: "new valid password"
         })
 
       assert is_nil(user.password)
@@ -317,7 +317,7 @@ defmodule Harmony.AccountTest do
 
       {:ok, _} =
         Account.update_user_password(user, valid_user_password(), %{
-          password: "new valid password"
+          password: "new valid password", password_confirmation: "new valid password"
         })
 
       refute Repo.get_by(UserToken, user_id: user.id)
@@ -503,19 +503,19 @@ defmodule Harmony.AccountTest do
 
     test "validates maximum values for password for security", %{user: user} do
       too_long = String.duplicate("db", 100)
-      {:error, changeset} = Account.reset_user_password(user, %{password: too_long})
+      {:error, changeset} = Account.reset_user_password(user, %{password: too_long, password_confirmation: too_long})
       assert "should be at most 72 character(s)" in errors_on(changeset).password
     end
 
     test "updates the password", %{user: user} do
-      {:ok, updated_user} = Account.reset_user_password(user, %{password: "new valid password"})
+      {:ok, updated_user} = Account.reset_user_password(user, %{password: "new valid password", password_confirmation: "new valid password"})
       assert is_nil(updated_user.password)
       assert Account.get_user_by_email_and_password(user.email, "new valid password")
     end
 
     test "deletes all tokens for the given user", %{user: user} do
       _ = Account.generate_user_session_token(user)
-      {:ok, _} = Account.reset_user_password(user, %{password: "new valid password"})
+      {:ok, _} = Account.reset_user_password(user, %{password: "new valid password", password_confirmation: "new valid password"})
       refute Repo.get_by(UserToken, user_id: user.id)
     end
   end

--- a/test/harmony_web/controllers/user_registration_controller_test.exs
+++ b/test/harmony_web/controllers/user_registration_controller_test.exs
@@ -42,12 +42,17 @@ defmodule HarmonyWeb.UserRegistrationControllerTest do
     test "render errors for invalid data", %{conn: conn} do
       conn =
         post(conn, Routes.user_registration_path(conn, :create), %{
-          "user" => %{"email" => "with spaces", "password" => "too short"}
+          "user" => %{
+            "email" => "with spaces",
+            "password" => "too short",
+            "password_confirmation" => "must match"
+          }
         })
 
       response = html_response(conn, 200)
       assert response =~ "<h1>Register</h1>"
       assert response =~ "must have the @ sign and no spaces"
+      assert response =~ "does not match"
       assert response =~ "should be at least 12 character"
     end
   end

--- a/test/harmony_web/features/user_signs_up_test.exs
+++ b/test/harmony_web/features/user_signs_up_test.exs
@@ -1,0 +1,24 @@
+defmodule HarmonyWeb.UserSignsUpTest do
+  use HarmonyWeb.FeatureCase, async: false
+
+  test "user can sign up", %{session: session} do
+    session
+    |> visit("/users/register")
+    |> fill_in(Query.text_field("Email"), with: "new_user@example.com")
+    |> fill_in(Query.css("#user_password"), with: "password1234")
+    |> fill_in(Query.text_field("Password confirmation"), with: "password1234")
+    |> click(Query.button("Register"))
+    |> assert_has(Query.css(".username", text: "new_user@example.com"))
+  end
+
+  test "user must confirm password when they sign up", %{session: session} do
+    session
+    |> visit("/users/register")
+    |> fill_in(Query.text_field("Email"), with: "new_user@example.com")
+    |> fill_in(Query.css("#user_password"), with: "password1234")
+    |> fill_in(Query.text_field("Password confirmation"), with: "nomatch")
+    |> click(Query.button("Register"))
+    |> refute_has(Query.css(".username", text: "new_user@example.com"))
+    |> assert_has(Query.css(".invalid-feedback", text: "does not match password"))
+  end
+end

--- a/test/harmony_web/features/user_signs_up_test.exs
+++ b/test/harmony_web/features/user_signs_up_test.exs
@@ -17,7 +17,7 @@ defmodule HarmonyWeb.UserSignsUpTest do
     session
     |> visit("/users/register")
     |> fill_in(Query.text_field("Email"), with: "new_user@example.com")
-    |> fill_in(Query.css("#user_password"), with: "password1234")
+    |> fill_in(Query.text_field("Password", at: 0, count: 2), with: "password1234")
     |> fill_in(Query.text_field("Password confirmation"), with: "nomatch")
     |> click(Query.button("Register"))
     |> refute_has(Query.css(".username", text: "new_user@example.com"))

--- a/test/harmony_web/features/user_signs_up_test.exs
+++ b/test/harmony_web/features/user_signs_up_test.exs
@@ -1,6 +1,7 @@
 defmodule HarmonyWeb.UserSignsUpTest do
   use HarmonyWeb.FeatureCase, async: false
 
+  @tag :noci
   test "user can sign up", %{session: session} do
     session
     |> visit("/users/register")
@@ -11,6 +12,7 @@ defmodule HarmonyWeb.UserSignsUpTest do
     |> assert_has(Query.css(".username", text: "new_user@example.com"))
   end
 
+  @tag :noci
   test "user must confirm password when they sign up", %{session: session} do
     session
     |> visit("/users/register")

--- a/test/support/fixtures/account_fixtures.ex
+++ b/test/support/fixtures/account_fixtures.ex
@@ -8,9 +8,11 @@ defmodule Harmony.AccountFixtures do
   def valid_user_password, do: "hello world!"
 
   def valid_user_attributes(attrs \\ %{}) do
+    password = valid_user_password()
     Enum.into(attrs, %{
       email: unique_user_email(),
-      password: valid_user_password()
+      password: password,
+      password_confirmation: password
     })
   end
 


### PR DESCRIPTION
As a user,
I expect the registration form to have a password confirmation field
And for a registration to return errors when my password and password confirmation do not match.

This feature adds a `validates_confirmation` to the registration changeset on the `User` module, similar to how it already existed on the default-generated `password_changeset` used by the "reset password" and "change password" forms.

The confirmation is marked as required, to ensure future form updates on the web side don't leave it out without explicitly changing this on the API side as well.